### PR TITLE
Update AzSubCleanerTimeTrigger to not use where-object

### DIFF
--- a/azure-function/AzSubCleanerTimeTrigger/run.ps1
+++ b/azure-function/AzSubCleanerTimeTrigger/run.ps1
@@ -14,7 +14,7 @@ $rgs = Get-AzResourceGroup;
  
 foreach($resourceGroup in $rgs){
     $name=  $resourceGroup.ResourceGroupName;
-    $count = (Get-AzResource | Where-Object{ $_.ResourceGroupName -match $name }).Count;
+    $count = (Get-AzResource -ResourceGroupName $name).Count;
     if($count -eq 0){
         Write-Host "==> $name is empty. Deleting it...";
         Remove-AzResourceGroup -Name $name -Force # -WhatIf #Add/Remove WhatIf when in Test/Production


### PR DESCRIPTION
Using the built in -ResourceGroupName parameter will make the API filter which will be considerably faster than piping to Where-Object and will prevent the task timing out on very large subscriptions or running into any weird regex issues with the name.